### PR TITLE
Precompute A/B Counts and Biallelic Summary Func

### DIFF
--- a/c/tskit/trees.c
+++ b/c/tskit/trees.c
@@ -2253,7 +2253,6 @@ norm_hap_weighted(tsk_size_t result_dim, const double *hap_weights,
     for (k = 0; k < result_dim; k++) {
         weight_row = GET_2D_ROW(hap_weights, 3, k);
         n = (double) args.sample_set_sizes[k];
-        // TODO: what to do when n = 0
         result[k] = weight_row[0] / n;
     }
     return 0;
@@ -2290,9 +2289,10 @@ norm_total_weighted(tsk_size_t result_dim, const double *TSK_UNUSED(hap_weights)
     tsk_size_t n_a, tsk_size_t n_b, double *result, void *TSK_UNUSED(params))
 {
     tsk_size_t k;
+    double norm = 1 / (double) (n_a * n_b);
 
     for (k = 0; k < result_dim; k++) {
-        result[k] = 1 / (double) (n_a * n_b);
+        result[k] = norm;
     }
     return 0;
 }
@@ -2316,40 +2316,21 @@ typedef struct {
     double *norm;
     double *result_tmp;
     tsk_bitset_t AB_samples;
-    tsk_bitset_t ss_A_samples;
-    tsk_bitset_t ss_B_samples;
-    tsk_bitset_t ss_AB_samples;
 } two_locus_work_t;
 
 static int
-two_locus_work_init(tsk_size_t max_alleles, tsk_size_t result_dim, tsk_size_t state_dim,
-    tsk_size_t num_samples, two_locus_work_t *out)
+two_locus_work_init(tsk_size_t max_alleles, tsk_size_t num_samples,
+    tsk_size_t result_dim, tsk_size_t state_dim, two_locus_work_t *out)
 {
     int ret = 0;
+
     out->weights = tsk_malloc(3 * state_dim * sizeof(*out->weights));
     out->norm = tsk_malloc(result_dim * sizeof(*out->norm));
     out->result_tmp
         = tsk_malloc(result_dim * max_alleles * max_alleles * sizeof(*out->result_tmp));
-
-    tsk_memset(&out->ss_A_samples, 0, sizeof(out->ss_A_samples));
-    tsk_memset(&out->ss_B_samples, 0, sizeof(out->ss_B_samples));
-    tsk_memset(&out->ss_AB_samples, 0, sizeof(out->ss_AB_samples));
     tsk_memset(&out->AB_samples, 0, sizeof(out->AB_samples));
-
     if (out->weights == NULL || out->norm == NULL || out->result_tmp == NULL) {
         ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
-        goto out;
-    }
-    ret = tsk_bitset_init(&out->ss_A_samples, num_samples, 1);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = tsk_bitset_init(&out->ss_B_samples, num_samples, 1);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = tsk_bitset_init(&out->ss_AB_samples, num_samples, 1);
-    if (ret != 0) {
         goto out;
     }
     ret = tsk_bitset_init(&out->AB_samples, num_samples, 1);
@@ -2367,17 +2348,14 @@ two_locus_work_free(two_locus_work_t *work)
     tsk_safe_free(work->norm);
     tsk_safe_free(work->result_tmp);
     tsk_bitset_free(&work->AB_samples);
-    tsk_bitset_free(&work->ss_A_samples);
-    tsk_bitset_free(&work->ss_B_samples);
-    tsk_bitset_free(&work->ss_AB_samples);
 }
 
 static int
-compute_general_two_site_stat_result(const tsk_bitset_t *state, tsk_size_t a_off,
-    tsk_size_t b_off, tsk_size_t num_a_alleles, tsk_size_t num_b_alleles,
-    tsk_size_t state_dim, const tsk_bitset_t *sample_sets, tsk_size_t result_dim,
-    general_stat_func_t *f, sample_count_stat_params_t *f_params, norm_func_t *norm_f,
-    bool polarised, two_locus_work_t *restrict work, double *result)
+compute_general_normed_two_site_stat_result(const tsk_bitset_t *state,
+    const tsk_size_t *allele_counts, tsk_size_t a_off, tsk_size_t b_off,
+    tsk_size_t num_a_alleles, tsk_size_t num_b_alleles, tsk_size_t state_dim,
+    tsk_size_t result_dim, general_stat_func_t *f, sample_count_stat_params_t *f_params,
+    norm_func_t *norm_f, bool polarised, two_locus_work_t *restrict work, double *result)
 {
     int ret = 0;
     // Sample sets and b sites are rows, a sites are columns
@@ -2387,33 +2365,24 @@ compute_general_two_site_stat_result(const tsk_bitset_t *state, tsk_size_t a_off
     // a3   [s1, s2, s3] [s1, s2, s3] [s1, s2, s3]
     tsk_size_t k, mut_a, mut_b, result_row_len = num_b_alleles * result_dim;
     uint8_t is_polarised = polarised ? 1 : 0;
-    double *hap_weight_row, *result_tmp_row;
-
-    double *norm = work->norm;
-    double *weights = work->weights;
-    double *result_tmp = work->result_tmp;
+    double *restrict hap_row, *restrict result_tmp_row;
+    double *restrict norm = work->norm;
+    double *restrict weights = work->weights;
+    double *restrict result_tmp = work->result_tmp;
     tsk_bitset_t AB_samples = work->AB_samples;
-    tsk_bitset_t ss_A_samples = work->ss_A_samples;
-    tsk_bitset_t ss_B_samples = work->ss_B_samples;
-    tsk_bitset_t ss_AB_samples = work->ss_AB_samples;
 
     for (mut_a = is_polarised; mut_a < num_a_alleles; mut_a++) {
         result_tmp_row = GET_2D_ROW(result_tmp, result_row_len, mut_a);
         for (mut_b = is_polarised; mut_b < num_b_alleles; mut_b++) {
-            tsk_bitset_intersect(
-                state, mut_a + a_off, state, mut_b + b_off, &AB_samples);
             for (k = 0; k < state_dim; k++) {
-                hap_weight_row = GET_2D_ROW(weights, 3, k);
-                tsk_bitset_intersect(
-                    state, mut_a + a_off, sample_sets, k, &ss_A_samples);
-                tsk_bitset_intersect(
-                    state, mut_b + b_off, sample_sets, k, &ss_B_samples);
-                tsk_bitset_intersect(&AB_samples, 0, sample_sets, k, &ss_AB_samples);
-                hap_weight_row[0] = (double) tsk_bitset_count(&ss_AB_samples, 0);
-                hap_weight_row[1]
-                    = (double) tsk_bitset_count(&ss_A_samples, 0) - hap_weight_row[0];
-                hap_weight_row[2]
-                    = (double) tsk_bitset_count(&ss_B_samples, 0) - hap_weight_row[0];
+                tsk_bitset_intersect(state, a_off + (mut_a * state_dim) + k, state,
+                    b_off + (mut_b * state_dim) + k, &AB_samples);
+                hap_row = GET_2D_ROW(weights, 3, k);
+                hap_row[0] = (double) tsk_bitset_count(&AB_samples, 0);
+                hap_row[1] = (double) allele_counts[a_off + (mut_a * state_dim) + k]
+                             - hap_row[0];
+                hap_row[2] = (double) allele_counts[b_off + (mut_b * state_dim) + k]
+                             - hap_row[0];
             }
             ret = f(state_dim, weights, result_dim, result_tmp_row, f_params);
             if (ret != 0) {
@@ -2430,7 +2399,37 @@ compute_general_two_site_stat_result(const tsk_bitset_t *state, tsk_size_t a_off
             result_tmp_row += result_dim; // Advance to the next column
         }
     }
+out:
+    return ret;
+}
 
+static int
+compute_general_two_site_stat_result(const tsk_bitset_t *state,
+    const tsk_size_t *allele_counts, tsk_size_t a_off, tsk_size_t b_off,
+    tsk_size_t state_dim, tsk_size_t result_dim, general_stat_func_t *f,
+    sample_count_stat_params_t *f_params, two_locus_work_t *restrict work,
+    double *result)
+{
+    int ret = 0;
+    tsk_size_t k;
+    tsk_bitset_t AB_samples = work->AB_samples;
+    tsk_size_t mut_a = 1, mut_b = 1;
+    double *restrict hap_row, *restrict weights = work->weights;
+
+    for (k = 0; k < state_dim; k++) {
+        tsk_bitset_intersect(state, a_off + (mut_a * state_dim) + k, state,
+            b_off + (mut_b * state_dim) + k, &AB_samples);
+        hap_row = GET_2D_ROW(weights, 3, k);
+        hap_row[0] = (double) tsk_bitset_count(&AB_samples, 0);
+        hap_row[1]
+            = (double) allele_counts[a_off + (mut_a * state_dim) + k] - hap_row[0];
+        hap_row[2]
+            = (double) allele_counts[b_off + (mut_b * state_dim) + k] - hap_row[0];
+    }
+    ret = f(state_dim, weights, result_dim, result, f_params);
+    if (ret != 0) {
+        goto out;
+    }
 out:
     return ret;
 }
@@ -2566,26 +2565,73 @@ out:
 }
 
 static int
+get_mutation_sample_sets(const tsk_bitset_t *allele_samples, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    const tsk_id_t *sample_index_map, tsk_size_t *max_ss_size,
+    tsk_bitset_t *allele_sample_sets, tsk_size_t **allele_sample_set_counts)
+{
+    int ret = 0;
+    tsk_bitset_val_t k, sample;
+    tsk_size_t i, j, ss_off;
+
+    *max_ss_size = 0;
+    for (i = 0; i < num_sample_sets; i++) {
+        if (sample_set_sizes[i] > *max_ss_size) {
+            *max_ss_size = sample_set_sizes[i];
+        }
+    }
+
+    *allele_sample_set_counts = tsk_calloc(
+        allele_samples->len * num_sample_sets, sizeof(**allele_sample_set_counts));
+    if (*allele_sample_set_counts == NULL) {
+        ret = tsk_trace_error(TSK_ERR_NO_MEMORY);
+        goto out;
+    }
+    ret = tsk_bitset_init(
+        allele_sample_sets, *max_ss_size, allele_samples->len * num_sample_sets);
+    if (ret != 0) {
+        goto out;
+    }
+
+    for (i = 0; i < allele_samples->len; i++) {
+        ss_off = 0;
+        for (j = 0; j < num_sample_sets; j++) {
+            for (k = 0; k < sample_set_sizes[j]; k++) {
+                sample = (tsk_bitset_val_t) sample_index_map[sample_sets[k + ss_off]];
+                if (tsk_bitset_contains(allele_samples, i, sample)) {
+                    tsk_bitset_set_bit(allele_sample_sets, j + i * num_sample_sets, k);
+                    (*allele_sample_set_counts)[j + i * num_sample_sets]++;
+                }
+            }
+            ss_off += sample_set_sizes[j];
+        }
+    }
+out:
+    return ret;
+}
+
+static int
 tsk_treeseq_two_site_count_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
-    const tsk_bitset_t *sample_sets, tsk_size_t result_dim, general_stat_func_t *f,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t result_dim, general_stat_func_t *f,
     sample_count_stat_params_t *f_params, norm_func_t *norm_f, tsk_size_t n_rows,
     const tsk_id_t *row_sites, tsk_size_t n_cols, const tsk_id_t *col_sites,
     tsk_flags_t options, double *result)
 {
-
     int ret = 0;
-    tsk_bitset_t allele_samples;
+    tsk_bitset_t allele_samples, allele_sample_sets;
     bool polarised = false;
     tsk_id_t *sites;
-    tsk_size_t r, c, s, max_alleles, n_alleles, n_sites, *row_idx, *col_idx;
+    tsk_size_t i, j, max_ss_size, max_alleles, n_alleles, n_sites, *row_idx, *col_idx;
     double *result_row;
     const tsk_size_t num_samples = self->num_samples;
-    tsk_size_t *num_alleles = NULL, *site_offsets = NULL;
+    tsk_size_t *num_alleles = NULL, *site_offsets = NULL, *allele_counts = NULL;
     tsk_size_t result_row_len = n_cols * result_dim;
     two_locus_work_t work;
 
     tsk_memset(&work, 0, sizeof(work));
     tsk_memset(&allele_samples, 0, sizeof(allele_samples));
+    tsk_memset(&allele_sample_sets, 0, sizeof(allele_sample_sets));
     sites = tsk_malloc(self->tables->sites.num_rows * sizeof(*sites));
     row_idx = tsk_malloc(self->tables->sites.num_rows * sizeof(*row_idx));
     col_idx = tsk_malloc(self->tables->sites.num_rows * sizeof(*col_idx));
@@ -2606,19 +2652,15 @@ tsk_treeseq_two_site_count_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     }
     n_alleles = 0;
     max_alleles = 0;
-    for (s = 0; s < n_sites; s++) {
-        site_offsets[s] = n_alleles;
-        n_alleles += self->site_mutations_length[sites[s]] + 1;
-        if (self->site_mutations_length[sites[s]] > max_alleles) {
-            max_alleles = self->site_mutations_length[sites[s]];
+    for (i = 0; i < n_sites; i++) {
+        site_offsets[i] = n_alleles * num_sample_sets;
+        n_alleles += self->site_mutations_length[sites[i]] + 1;
+        if (self->site_mutations_length[sites[i]] > max_alleles) {
+            max_alleles = self->site_mutations_length[sites[i]];
         }
     }
-    max_alleles++;
+    max_alleles++; // add 1 for the ancestral allele
 
-    ret = two_locus_work_init(max_alleles, result_dim, state_dim, num_samples, &work);
-    if (ret != 0) {
-        goto out;
-    }
     ret = tsk_bitset_init(&allele_samples, num_samples, n_alleles);
     if (ret != 0) {
         goto out;
@@ -2628,20 +2670,37 @@ tsk_treeseq_two_site_count_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
     if (ret != 0) {
         goto out;
     }
+    ret = get_mutation_sample_sets(&allele_samples, num_sample_sets, sample_set_sizes,
+        sample_sets, self->sample_index_map, &max_ss_size, &allele_sample_sets,
+        &allele_counts);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = two_locus_work_init(max_alleles, max_ss_size, result_dim, state_dim, &work);
+    if (ret != 0) {
+        goto out;
+    }
 
     if (options & TSK_STAT_POLARISED) {
         polarised = true;
     }
 
     // For each row/column pair, fill in the sample set in the result matrix.
-    for (r = 0; r < n_rows; r++) {
-        result_row = GET_2D_ROW(result, result_row_len, r);
-        for (c = 0; c < n_cols; c++) {
-            ret = compute_general_two_site_stat_result(&allele_samples,
-                site_offsets[row_idx[r]], site_offsets[col_idx[c]],
-                num_alleles[row_idx[r]], num_alleles[col_idx[c]], state_dim, sample_sets,
-                result_dim, f, f_params, norm_f, polarised, &work,
-                &(result_row[c * result_dim]));
+    for (i = 0; i < n_rows; i++) {
+        result_row = GET_2D_ROW(result, result_row_len, i);
+        for (j = 0; j < n_cols; j++) {
+            if (num_alleles[row_idx[i]] == 2 && num_alleles[col_idx[j]] == 2) {
+                ret = compute_general_two_site_stat_result(&allele_sample_sets,
+                    allele_counts, site_offsets[row_idx[i]], site_offsets[col_idx[j]],
+                    state_dim, result_dim, f, f_params, &work,
+                    &(result_row[j * result_dim]));
+            } else {
+                ret = compute_general_normed_two_site_stat_result(&allele_sample_sets,
+                    allele_counts, site_offsets[row_idx[i]], site_offsets[col_idx[j]],
+                    num_alleles[row_idx[i]], num_alleles[col_idx[j]], state_dim,
+                    result_dim, f, f_params, norm_f, polarised, &work,
+                    &(result_row[j * result_dim]));
+            }
             if (ret != 0) {
                 goto out;
             }
@@ -2654,8 +2713,10 @@ out:
     tsk_safe_free(col_idx);
     tsk_safe_free(num_alleles);
     tsk_safe_free(site_offsets);
+    tsk_safe_free(allele_counts);
     two_locus_work_free(&work);
     tsk_bitset_free(&allele_samples);
+    tsk_bitset_free(&allele_sample_sets);
     return ret;
 }
 
@@ -3049,14 +3110,13 @@ compute_two_tree_branch_stat(const tsk_treeseq_t *ts, const iter_state *l_state,
     const tsk_id_t *restrict edges_child = ts->tables->edges.child;
     const tsk_id_t *restrict edges_parent = ts->tables->edges.parent;
     const tsk_size_t num_nodes = ts->tables->nodes.num_rows;
-    const tsk_size_t num_samples = ts->num_samples;
     tsk_bitset_t updates, *r_samples = r_state->node_samples;
     two_locus_work_t work;
 
     tsk_memset(&work, 0, sizeof(work));
     tsk_memset(&updates, 0, sizeof(updates));
     // only two alleles are possible for branch stats
-    ret = two_locus_work_init(2, result_dim, state_dim, num_samples, &work);
+    ret = two_locus_work_init(2, ts->num_samples, result_dim, state_dim, &work);
     if (ret != 0) {
         goto out;
     }
@@ -3140,7 +3200,8 @@ out:
 
 static int
 tsk_treeseq_two_branch_count_stat(const tsk_treeseq_t *self, tsk_size_t state_dim,
-    const tsk_bitset_t *sample_sets, tsk_size_t result_dim, general_stat_func_t *f,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t result_dim, general_stat_func_t *f,
     sample_count_stat_params_t *f_params, norm_func_t *TSK_UNUSED(norm_f),
     tsk_size_t n_rows, const double *row_positions, tsk_size_t n_cols,
     const double *col_positions, tsk_flags_t TSK_UNUSED(options), double *result)
@@ -3149,11 +3210,12 @@ tsk_treeseq_two_branch_count_stat(const tsk_treeseq_t *self, tsk_size_t state_di
     int r, c;
     tsk_id_t *row_indexes = NULL, *col_indexes = NULL;
     tsk_size_t i, j, k, row, col, *row_repeats = NULL, *col_repeats = NULL;
-    tsk_bitset_t node_samples;
+    tsk_bitset_t node_samples, sample_sets_bits;
     iter_state l_state, r_state;
     double *result_tmp = NULL, *result_row;
     const tsk_size_t num_nodes = self->tables->nodes.num_rows;
 
+    tsk_memset(&sample_sets_bits, 0, sizeof(sample_sets_bits));
     tsk_memset(&node_samples, 0, sizeof(node_samples));
     tsk_memset(&l_state, 0, sizeof(l_state));
     tsk_memset(&r_state, 0, sizeof(r_state));
@@ -3167,6 +3229,11 @@ tsk_treeseq_two_branch_count_stat(const tsk_treeseq_t *self, tsk_size_t state_di
         goto out;
     }
     ret = iter_state_init(&r_state, self, state_dim);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = sample_sets_to_bitset(
+        self, sample_set_sizes, sample_sets, num_sample_sets, &sample_sets_bits);
     if (ret != 0) {
         goto out;
     }
@@ -3186,7 +3253,7 @@ tsk_treeseq_two_branch_count_stat(const tsk_treeseq_t *self, tsk_size_t state_di
     if (ret != 0) {
         goto out;
     }
-    ret = get_node_samples(self, state_dim, sample_sets, &node_samples);
+    ret = get_node_samples(self, state_dim, &sample_sets_bits, &node_samples);
     if (ret != 0) {
         goto out;
     }
@@ -3238,6 +3305,41 @@ out:
     iter_state_free(&l_state);
     iter_state_free(&r_state);
     tsk_bitset_free(&node_samples);
+    tsk_bitset_free(&sample_sets_bits);
+    return ret;
+}
+
+static int
+check_sample_set_dups(tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, const tsk_id_t *restrict sample_index_map,
+    tsk_size_t num_samples)
+{
+    int ret;
+    tsk_size_t j, k, l;
+    tsk_id_t u, sample_index;
+    tsk_bitset_t tmp;
+
+    tsk_memset(&tmp, 0, sizeof(tmp));
+    ret = tsk_bitset_init(&tmp, num_samples, 1);
+    if (ret != 0) {
+        return ret;
+    }
+    j = 0;
+    for (k = 0; k < num_sample_sets; k++) {
+        tsk_memset(tmp.data, 0, sizeof(*tmp.data) * tmp.row_len);
+        for (l = 0; l < sample_set_sizes[k]; l++) {
+            u = sample_sets[j];
+            sample_index = sample_index_map[u];
+            if (tsk_bitset_contains(&tmp, 0, (tsk_bitset_val_t) sample_index)) {
+                ret = tsk_trace_error(TSK_ERR_DUPLICATE_SAMPLE);
+                goto out;
+            }
+            tsk_bitset_set_bit(&tmp, 0, (tsk_bitset_val_t) sample_index);
+            j++;
+        }
+    }
+out:
+    tsk_bitset_free(&tmp);
     return ret;
 }
 
@@ -3252,7 +3354,6 @@ tsk_treeseq_two_locus_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sampl
     // TODO: generalize this function if we ever decide to do weighted two_locus stats.
     //       We only implement count stats and therefore we don't handle weights.
     int ret = 0;
-    tsk_bitset_t sample_sets_bits;
     bool stat_site = !!(options & TSK_STAT_SITE);
     bool stat_branch = !!(options & TSK_STAT_BRANCH);
     tsk_size_t state_dim = num_sample_sets;
@@ -3260,8 +3361,6 @@ tsk_treeseq_two_locus_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sampl
         .num_sample_sets = num_sample_sets,
         .sample_set_sizes = sample_set_sizes,
         .set_indexes = set_indexes };
-
-    tsk_memset(&sample_sets_bits, 0, sizeof(sample_sets_bits));
 
     // We do not support two-locus node stats
     if (!!(options & TSK_STAT_NODE)) {
@@ -3286,12 +3385,6 @@ tsk_treeseq_two_locus_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sampl
         ret = tsk_trace_error(TSK_ERR_BAD_RESULT_DIMS);
         goto out;
     }
-    ret = sample_sets_to_bitset(
-        self, sample_set_sizes, sample_sets, num_sample_sets, &sample_sets_bits);
-    if (ret != 0) {
-        goto out;
-    }
-
     if (stat_site) {
         ret = check_sites(row_sites, out_rows, self->tables->sites.num_rows);
         if (ret != 0) {
@@ -3301,9 +3394,15 @@ tsk_treeseq_two_locus_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sampl
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_treeseq_two_site_count_stat(self, state_dim, &sample_sets_bits,
-            result_dim, f, &f_params, norm_f, out_rows, row_sites, out_cols, col_sites,
-            options, result);
+        ret = check_sample_set_dups(num_sample_sets, sample_set_sizes, sample_sets,
+            self->sample_index_map, self->num_samples);
+        if (ret != 0) {
+            goto out;
+        }
+        // TODO: result dim/state dim can be set internally now.
+        ret = tsk_treeseq_two_site_count_stat(self, state_dim, num_sample_sets,
+            sample_set_sizes, sample_sets, result_dim, f, &f_params, norm_f, out_rows,
+            row_sites, out_cols, col_sites, options, result);
     } else if (stat_branch) {
         ret = check_positions(
             row_positions, out_rows, tsk_treeseq_get_sequence_length(self));
@@ -3315,13 +3414,11 @@ tsk_treeseq_two_locus_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sampl
         if (ret != 0) {
             goto out;
         }
-        ret = tsk_treeseq_two_branch_count_stat(self, state_dim, &sample_sets_bits,
-            result_dim, f, &f_params, norm_f, out_rows, row_positions, out_cols,
-            col_positions, options, result);
+        ret = tsk_treeseq_two_branch_count_stat(self, state_dim, num_sample_sets,
+            sample_set_sizes, sample_sets, result_dim, f, &f_params, norm_f, out_rows,
+            row_positions, out_cols, col_positions, options, result);
     }
-
 out:
-    tsk_bitset_free(&sample_sets_bits);
     return ret;
 }
 


### PR DESCRIPTION
Precompute A/B counts for each sample set. We were previously computing them redundantly each for each site pair in our results matrix. The precomputation happens in a function called `get_mutation_sample_sets`, which takes our list of sets (`tsk_bitset_t`) for each mutation and intersects the samples with a particular mutation with the sample sets passed in by the user. The result is an expanded list of sets with one set per mutation per sample set. During this operation, we compute the number of samples containing the given allele for each mutation, avoiding the need to perform redundant count operations on the data.

In addition to precomputation, we add a non-normalized version of `compute_general_two_site_stat_result` for situations where we're computing stats from biallelic loci. We dispatch the computation of the result based on the number of alleles in the two loci we're comparing. If the number of alleles in both loci is 2, then we simply perform an LD computation on the derived alleles for the two loci. As a result, we remove the need to compute a matrix of LD values, then take a weighted sum. This is much more efficient and means that we only run the full multiallelic LD routine on sites that are multiallelic.
